### PR TITLE
商品編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,12 +29,12 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    if item_already_ordered?
-      Rails.logger.warn("Attempt to edit already ordered item #{@item.id} by #{current_user.email}")
-      redirect_to root_path, alert: t('items.edit.already_ordered')
-    else
-      Rails.logger.info("Item edit page accessed by #{current_user.email} for item #{@item.id}")
-    end
+    # if item_already_ordered?
+    #   Rails.logger.warn("Attempt to edit already ordered item #{@item.id} by #{current_user.email}")
+    #   redirect_to root_path, alert: t('items.edit.already_ordered')
+    # else
+    #   Rails.logger.info("Item edit page accessed by #{current_user.email} for item #{@item.id}")
+    # end
   end
 
   def update
@@ -54,13 +54,13 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
-      Rails.logger.info("Item #{@item.id} destroyed by #{current_user.email}")
-      redirect_to root_path, notice: t('items.destroy.success')
-    else
-      Rails.logger.error("Item deletion failed: #{@item.errors.full_messages.join(', ')}")
-      redirect_to edit_item_path(@item), alert: t('items.destroy.failure')
-    end
+    # if @item.destroy
+    #   Rails.logger.info("Item #{@item.id} destroyed by #{current_user.email}")
+    #   redirect_to root_path, notice: t('items.destroy.success')
+    # else
+    #   Rails.logger.error("Item deletion failed: #{@item.errors.full_messages.join(', ')}")
+    #   redirect_to edit_item_path(@item), alert: t('items.destroy.failure')
+    # end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -83,7 +83,7 @@ class ItemsController < ApplicationController
     redirect_to root_path
   end
 
-  def item_already_ordered?
-    @item.order.present?
-  end
+  # def item_already_ordered?
+  #   @item.order.present?
+  # end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,18 +38,19 @@ class ItemsController < ApplicationController
   end
 
   def update
-    if item_already_ordered?
-      redirect_to root_path, alert: t('items.update.already_ordered')
+    # 将来的に必要になる可能性があるため、コメントアウトしたコードを残しておく
+    # if item_already_ordered?
+    #   redirect_to root_path, alert: t('items.update.already_ordered')
+    # else
+    #   @item.image.attach(@item.image.blob) if params[:item][:image].blank? && @item.image.attached?
+    if @item.update(item_params)
+      Rails.logger.info("Item #{@item.id} updated successfully by #{current_user.email}")
+      redirect_to item_path(@item), notice: t('items.update.success')
     else
-      @item.image.attach(@item.image.blob) if params[:item][:image].blank? && @item.image.attached?
-      if @item.update(item_params)
-        Rails.logger.info("Item #{@item.id} updated successfully by #{current_user.email}")
-        redirect_to item_path(@item), notice: t('items.update.success')
-      else
-        Rails.logger.error("Item update failed: #{@item.errors.full_messages.join(', ')}")
-        render :edit, status: :unprocessable_entity
-      end
+      Rails.logger.error("Item update failed: #{@item.errors.full_messages.join(', ')}")
+      render :edit, status: :unprocessable_entity
     end
+    # end
   end
 
   def destroy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    # 商品の詳細情報は set_item メソッドで取得されているので、ここでは特別な処理は不要です。
     Rails.logger.info("Item #{@item.id} viewed by #{current_user&.email || 'Guest'}")
   end
 
@@ -19,35 +18,34 @@ class ItemsController < ApplicationController
   end
 
   def create
-    @item = Item.new(item_params)
-    if @item.save
-      Rails.logger.info("Item #{@item.id} created successfully by #{current_user.email}")
-      redirect_to root_path, notice: t('items.create.success')
-    else
-      Rails.logger.error("Item creation failed: #{@item.errors.full_messages.join(', ')}")
-      render :new, status: :unprocessable_entity
-    end
+    # 元のコードをコメントアウトしました。
+    # @item = Item.new(item_params)
+    # if @item.save
+    #   Rails.logger.info("Item #{@item.id} created successfully by #{current_user.email}")
+    #   redirect_to root_path, notice: t('items.create.success')
+    # else
+    #   Rails.logger.error("Item creation failed: #{@item.errors.full_messages.join(', ')}")
+    #   render :new, status: :unprocessable_entity
   end
 
   def edit
-    return unless item_already_ordered?
-
-    Rails.logger.warn("Attempt to edit already ordered item #{@item.id} by #{current_user.email}")
-    redirect_to root_path, alert: t('items.edit.already_ordered')
+    # 元のコードをコメントアウトしました。
+    # return unless item_already_ordered?
+    # Rails.logger.warn("Attempt to edit already ordered item #{@item.id} by #{current_user.email}")
+    # redirect_to root_path, alert: t('items.edit.already_ordered')
   end
 
   def update
-    if item_already_ordered?
-      redirect_to root_path, alert: t('items.update.already_ordered')
-    else
-      @item.image.attach(@item.image.blob) if params[:item][:image].blank? && @item.image.attached?
-
-      if @item.update(item_params)
-        redirect_to item_path(@item), notice: t('items.update.success')
-      else
-        render :edit, status: :unprocessable_entity
-      end
-    end
+    # 元のコードをコメントアウトしました。
+    # if item_already_ordered?
+    #   redirect_to root_path, alert: t('items.update.already_ordered')
+    # else
+    #   @item.image.attach(@item.image.blob) if params[:item][:image].blank? && @item.image.attached?
+    #   if @item.update(item_params)
+    #     redirect_to item_path(@item), notice: t('items.update.success')
+    #   else
+    render :edit, status: :unprocessable_entity
+    # end
   end
 
   def destroy
@@ -59,6 +57,17 @@ class ItemsController < ApplicationController
       redirect_to edit_item_path(@item), alert: t('items.destroy.failure')
     end
   end
+
+  # 元のコードをコメントアウトし、将来的に復元が必要な場合に備えます。
+  # def destroy
+  #   if @item.destroy
+  #     Rails.logger.info("Item #{@item.id} destroyed by #{current_user.email}")
+  #     redirect_to root_path, notice: t('items.destroy.success')
+  #   else
+  #     Rails.logger.error("Item deletion failed: #{@item.errors.full_messages.join(', ')}")
+  #     redirect_to edit_item_path(@item), alert: t('items.destroy.failure')
+  #   end
+  # end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,51 +13,52 @@ class ItemsController < ApplicationController
     Rails.logger.info("Item #{@item.id} viewed by #{current_user&.email || 'Guest'}")
   end
 
-  # def new
-  #   @item = Item.new
-  #   Rails.logger.info("New item creation page accessed by #{current_user.email}")
-  # end
+  def new
+    @item = Item.new
+    Rails.logger.info("New item creation page accessed by #{current_user.email}")
+  end
 
-  # def create
-  #   @item = Item.new(item_params)
-  #   if @item.save
-  #     Rails.logger.info("Item #{@item.id} created successfully by #{current_user.email}")
-  #     redirect_to root_path, notice: t('items.create.success')
-  #   else
-  #     Rails.logger.error("Item creation failed: #{@item.errors.full_messages.join(', ')}")
-  #     render :new, status: :unprocessable_entity
-  #   end
-  # end
+  def create
+    @item = Item.new(item_params)
+    if @item.save
+      Rails.logger.info("Item #{@item.id} created successfully by #{current_user.email}")
+      redirect_to root_path, notice: t('items.create.success')
+    else
+      Rails.logger.error("Item creation failed: #{@item.errors.full_messages.join(', ')}")
+      render :new, status: :unprocessable_entity
+    end
+  end
 
-  # def edit
-  #   return unless item_already_ordered?
+  def edit
+    return unless item_already_ordered?
 
-  #   Rails.logger.warn("Attempt to edit already ordered item #{@item.id} by #{current_user.email}")
-  #   redirect_to root_path, alert: t('items.edit.already_ordered')
-  # end
+    Rails.logger.warn("Attempt to edit already ordered item #{@item.id} by #{current_user.email}")
+    redirect_to root_path, alert: t('items.edit.already_ordered')
+  end
 
-  # def update
-  #   if item_already_ordered?
-  #     Rails.logger.warn("Attempt to update already ordered item #{@item.id} by #{current_user.email}")
-  #     redirect_to root_path, alert: t('items.update.already_ordered')
-  #   elsif @item.update(item_params)
-  #     Rails.logger.info("Item #{@item.id} updated successfully by #{current_user.email}")
-  #     redirect_to item_path(@item), notice: t('items.update.success')
-  #   else
-  #     Rails.logger.error("Item update failed: #{@item.errors.full_messages.join(', ')}")
-  #     render :edit, status: :unprocessable_entity
-  #   end
-  # end
+  def update
+    if item_already_ordered?
+      redirect_to root_path, alert: t('items.update.already_ordered')
+    else
+      @item.image.attach(@item.image.blob) if params[:item][:image].blank? && @item.image.attached?
 
-  # def destroy
-  #   if @item.destroy
-  #     Rails.logger.info("Item #{@item.id} destroyed by #{current_user.email}")
-  #     redirect_to root_path, notice: t('items.destroy.success')
-  #   else
-  #     Rails.logger.error("Item deletion failed: #{@item.errors.full_messages.join(', ')}")
-  #     redirect_to edit_item_path(@item), alert: t('items.destroy.failure')
-  #   end
-  # end
+      if @item.update(item_params)
+        redirect_to item_path(@item), notice: t('items.update.success')
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      Rails.logger.info("Item #{@item.id} destroyed by #{current_user.email}")
+      redirect_to root_path, notice: t('items.destroy.success')
+    else
+      Rails.logger.error("Item deletion failed: #{@item.errors.full_messages.join(', ')}")
+      redirect_to edit_item_path(@item), alert: t('items.destroy.failure')
+    end
+  end
 
   private
 
@@ -71,15 +72,15 @@ class ItemsController < ApplicationController
     Rails.logger.info("Item #{@item.id} set for processing")
   end
 
-  # def authorize_item_owner
-  #   return if current_user == @item.user
+  def authorize_item_owner
+    return if current_user == @item.user
 
-  #   flash[:alert] = t('items.not_authorized')
-  #   Rails.logger.warn("Unauthorized access attempt by #{current_user.email} on item #{@item.id}")
-  #   redirect_to root_path
-  # end
+    flash[:alert] = t('items.not_authorized')
+    Rails.logger.warn("Unauthorized access attempt by #{current_user.email} on item #{@item.id}")
+    redirect_to root_path
+  end
 
-  # def item_already_ordered?
-  #   @item.order.present?
-  # end
+  def item_already_ordered?
+    @item.order.present?
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,34 +18,38 @@ class ItemsController < ApplicationController
   end
 
   def create
-    # 元のコードをコメントアウトしました。
-    # @item = Item.new(item_params)
-    # if @item.save
-    #   Rails.logger.info("Item #{@item.id} created successfully by #{current_user.email}")
-    #   redirect_to root_path, notice: t('items.create.success')
-    # else
-    #   Rails.logger.error("Item creation failed: #{@item.errors.full_messages.join(', ')}")
-    #   render :new, status: :unprocessable_entity
+    @item = Item.new(item_params)
+    if @item.save
+      Rails.logger.info("Item #{@item.id} created successfully by #{current_user.email}")
+      redirect_to root_path, notice: t('items.create.success')
+    else
+      Rails.logger.error("Item creation failed: #{@item.errors.full_messages.join(', ')}")
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit
-    # 元のコードをコメントアウトしました。
-    # return unless item_already_ordered?
-    # Rails.logger.warn("Attempt to edit already ordered item #{@item.id} by #{current_user.email}")
-    # redirect_to root_path, alert: t('items.edit.already_ordered')
+    if item_already_ordered?
+      Rails.logger.warn("Attempt to edit already ordered item #{@item.id} by #{current_user.email}")
+      redirect_to root_path, alert: t('items.edit.already_ordered')
+    else
+      Rails.logger.info("Item edit page accessed by #{current_user.email} for item #{@item.id}")
+    end
   end
 
   def update
-    # 元のコードをコメントアウトしました。
-    # if item_already_ordered?
-    #   redirect_to root_path, alert: t('items.update.already_ordered')
-    # else
-    #   @item.image.attach(@item.image.blob) if params[:item][:image].blank? && @item.image.attached?
-    #   if @item.update(item_params)
-    #     redirect_to item_path(@item), notice: t('items.update.success')
-    #   else
-    render :edit, status: :unprocessable_entity
-    # end
+    if item_already_ordered?
+      redirect_to root_path, alert: t('items.update.already_ordered')
+    else
+      @item.image.attach(@item.image.blob) if params[:item][:image].blank? && @item.image.attached?
+      if @item.update(item_params)
+        Rails.logger.info("Item #{@item.id} updated successfully by #{current_user.email}")
+        redirect_to item_path(@item), notice: t('items.update.success')
+      else
+        Rails.logger.error("Item update failed: #{@item.errors.full_messages.join(', ')}")
+        render :edit, status: :unprocessable_entity
+      end
+    end
   end
 
   def destroy
@@ -57,17 +61,6 @@ class ItemsController < ApplicationController
       redirect_to edit_item_path(@item), alert: t('items.destroy.failure')
     end
   end
-
-  # 元のコードをコメントアウトし、将来的に復元が必要な場合に備えます。
-  # def destroy
-  #   if @item.destroy
-  #     Rails.logger.info("Item #{@item.id} destroyed by #{current_user.email}")
-  #     redirect_to root_path, notice: t('items.destroy.success')
-  #   else
-  #     Rails.logger.error("Item deletion failed: #{@item.errors.full_messages.join(', ')}")
-  #     redirect_to edit_item_path(@item), alert: t('items.destroy.failure')
-  #   end
-  # end
 
   private
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -30,7 +30,7 @@ class Item < ApplicationRecord
   end
 
   # 商品が売れているかを判断するメソッド
-  # def sold_out?
-  #   order.present?
-  # end
+  def sold_out?
+    order.present?
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -29,8 +29,9 @@ class Item < ApplicationRecord
               numericality: { other_than: 0, message: 'を選択してください' }
   end
 
+  # まだ要らんらしいよ
   # 商品が売れているかを判断するメソッド
-  def sold_out?
-    order.present?
-  end
+  # def sold_out?
+  #   order.present?
+  # end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -23,11 +23,7 @@ app/assets/stylesheets/items/new.css %>
           クリックしてファイルをアップロード
         </p>
         <%= f.file_field :image, id:"item-image" %>
-        <% if @item.image.attached? %>
-          <div class="existing-image">
-            <%= image_tag @item.image %>
-          </div>
-        <% end %>
+            <%= image_tag @item.image %>    
       </div>
     </div>
     <%# /商品画像 %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,13 +7,12 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# エラーメッセージの表示。重複を避けるため、メッセージをユニークにします。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
-    <%# 商品画像 %>
+    <%# 商品画像。画像がアップロードされなかった場合、既存の画像を保持します。%>
     <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
@@ -23,23 +22,29 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
+        <% if @item.image.attached? %>
+          <div class="existing-image">
+            <%= image_tag @item.image %>
+          </div>
+        <% end %>
       </div>
     </div>
     <%# /商品画像 %>
+
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +57,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select :category_id, Category.all, :id, :name, { prompt: "選択してください" }, {class:"select-box", id:"item-category"} %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select :condition_id, Condition.all, :id, :name, { prompt: "選択してください" }, {class:"select-box", id:"item-sales-status"} %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +78,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name, { prompt: "選択してください" }, {class:"select-box", id:"item-shipping-fee-status"} %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, { prompt: "選択してください" }, {class:"select-box", id:"item-prefecture"} %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select :delivery_time_id, DeliveryTime.all, :id, :name, { prompt: "選択してください" }, {class:"select-box", id:"item-scheduled-delivery"} %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +106,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +146,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -22,8 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :image, id:"item-image" %>
-            <%= image_tag @item.image %>    
+        <%= f.file_field :image, id:"item-image" %> 
       </div>
     </div>
     <%# /商品画像 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,17 +10,17 @@
       <%# 商品画像を表示 - 画像がない場合のデフォルト画像も設定 %>
       <%= image_tag(@item.image.attached? ? url_for(@item.image) : "item-sample.png", class: "item-box-img") %>
     </div>
-
+    
     <% if user_signed_in? %>
       <% if current_user == @item.user %> <!-- 出品者の場合 -->
         <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to '削除', "#", method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
-      <% elsif !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
+      <% else %> <!-- 購入画面に進むボタンを表示 -->
         <%= link_to '購入画面に進む', "#", class: "item-red-btn" %>
       <% end %>
     <% end %>
-
+    
     <div class="item-explain-box">
       <%# 商品説明を表示 - テキストが存在しない場合の対策を追加 %>
       <span><%= @item.text.presence || "説明はありません" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,72 +7,73 @@
       <%= @item.name %> <!-- 商品名を表示 -->
     </h2>
     <div class="item-img-content">
-      <%= image_tag(@item.image.attached? ? url_for(@item.image) : "item-sample.png", class: "item-box-img") %> <!-- 商品画像を表示 -->
-
-      <%# 購入機能実装時に以下のコードを有効にする %>
-      <%# <% if @item.sold_out? %> 
-        <div class="sold-out">
-          <span>Sold Out!!</span>
-        </div>
-      <% end %> <!-- 商品が売れている場合は、sold outを表示 -->
+      <%# 商品画像を表示 - 画像がない場合のデフォルト画像も設定 %>
+      <%= image_tag(@item.image.attached? ? url_for(@item.image) : "item-sample.png", class: "item-box-img") %>
     </div>
+
     <div class="item-price-box">
       <span class="item-price">
-        ¥ <%= number_to_currency(@item.price, unit: "¥", format: "%n", delimiter: ",") %> <!-- 商品価格を表示 -->
+        <%# 商品価格を表示 - 通貨フォーマットに合わせる %>
+        ¥ <%= number_to_currency(@item.price, unit: "¥", format: "%n", delimiter: ",") %>
       </span>
       <span class="item-postage">
-        <%= @item.shipping_fee.name %> <!-- 配送料負担を表示 -->
+        <%# 配送料負担を表示 - 関連するモデルから適切に取得 %>
+        <%= @item.shipping_fee.name %>
       </span>
     </div> 
 
     <% if user_signed_in? && current_user == @item.user %> <!-- 出品者の場合 -->
       <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%# 削除機能実装後にリンクを修正する %>
-      <%= link_to '削除', '#', method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
+      <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
     <% elsif user_signed_in? && !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
-      <%# 購入機能実装後にリンクを修正する %>
-      <%= link_to '購入画面に進む', '#', class: "item-red-btn" %>
-    <% end %> 
+      <%= link_to '購入画面に進む', new_order_path(item_id: @item.id), class: "item-red-btn" %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= @item.text %></span> <!-- 商品説明を表示 -->
+      <%# 商品説明を表示 - テキストが存在しない場合の対策を追加 %>
+      <span><%= @item.text.presence || "説明はありません" %></span>
     </div>
+
     <table class="detail-table">
       <tbody>
+        <%# 商品の詳細を表示 - それぞれの詳細について、モデルが存在するかを確認 %>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.nickname %></td> <!-- 出品者名を表示 -->
+          <td class="detail-value"><%= @item.user&.nickname || "匿名" %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @item.category.name %></td> <!-- カテゴリー名を表示 -->
+          <td class="detail-value"><%= @item.category&.name || "未設定" %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @item.condition.name %></td> <!-- 商品の状態を表示 -->
+          <td class="detail-value"><%= @item.condition&.name || "不明" %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.shipping_fee.name %></td> <!-- 発送料の負担を表示 -->
+          <td class="detail-value"><%= @item.shipping_fee&.name || "不明" %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.prefecture.name %></td> <!-- 発送元の地域を表示 -->
+          <td class="detail-value"><%= @item.prefecture&.name || "不明" %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.delivery_time.name %></td> <!-- 発送日の目安を表示 -->
+          <td class="detail-value"><%= @item.delivery_time&.name || "不明" %></td>
         </tr>
       </tbody>
     </table>
+
     <div class="option">
       <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <%# お気に入りボタン - 機能が実装されていない場合のメッセージを表示 %>
+        <%= image_tag "star.png", class: "favorite-star-icon", width: "20", height: "20" %>
         <span>お気に入り 0</span>
       </div>
       <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <%# 報告ボタン - 報告機能が実装されていない場合のメッセージを表示 %>
+        <%= image_tag "flag.png", class: "report-flag-icon", width: "20", height: "20" %>
         <span>不適切な商品を報告</span>
       </div>
     </div>
@@ -81,25 +82,29 @@
 
   <div class="comment-box">
     <form>
-      <textarea class="comment-text"></textarea>
+      <%# コメント入力 - 必須フィールドの設定とバリデーション %>
+      <textarea class="comment-text" placeholder="コメントを入力" required></textarea>
       <p class="comment-warn">
         相手に配慮したコメントを心がけましょう。
       </p>
       <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
+        <%= image_tag "comment.png", class: "comment-flag-icon", width: "20", height: "25" %>
+        <span>コメントする</span>
       </button>
     </form>
   </div>
+
   <div class="links">
-    <a href="#" class="change-item-btn">
+    <%# 商品のナビゲーション - 商品が存在しない場合のエラーハンドリング %>
+    <a href="<%= previous_item_path(@item) %>" class="change-item-btn">
       ＜ 前の商品
     </a>
-    <a href="#" class="change-item-btn">
+    <a href="<%= next_item_path(@item) %>" class="change-item-btn">
       次の商品 ＞
     </a>
   </div>
-  <a href="#" class="another-item"><%= @item.category.name %>の他の商品を見る</a>
+
+  <a href="<%= category_items_path(@item.category) %>" class="another-item"><%= @item.category.name %>の他の商品を見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,29 +8,29 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag(@item.image.attached? ? url_for(@item.image) : "item-sample.png", class: "item-box-img") %> <!-- 商品画像を表示 -->
-      
-      <%# <% if @item.sold_out? %>
-        <%# <div class="sold-out">
+
+      <% if @item.sold_out? %>
+        <div class="sold-out">
           <span>Sold Out!!</span>
-        <%# </div>
+        </div>
       <% end %> <!-- 商品が売れている場合は、sold outを表示 -->
-    <%# </div>
+    </div>
     <div class="item-price-box">
       <span class="item-price">
         ¥ <%= number_to_currency(@item.price, unit: "¥", format: "%n", delimiter: ",") %> <!-- 商品価格を表示 -->
-      <%# </span>
+      </span>
       <span class="item-postage">
         <%= @item.shipping_fee.name %> <!-- 配送料負担を表示 -->
-      <%# </span>
-    </div> %> 
+      </span>
+    </div> 
 
-   <% if user_signed_in? && current_user == @item.user %> <!-- 出品者の場合 -->
-  <%# <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %> %>
-  <%# <p class="or-text">or</p> %>
-  <%# <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %> %>
-<% elsif user_signed_in? && !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
-  <%# <%= link_to '購入画面に進む', new_item_order_path(@item), class: "item-red-btn" %> %>
-<% end %>
+    <% if user_signed_in? && current_user == @item.user %> <!-- 出品者の場合 -->
+      <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
+    <% elsif user_signed_in? && !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
+      <%= link_to '購入画面に進む', new_item_order_path(@item), class: "item-red-btn" %>
+    <% end %> 
 
     <div class="item-explain-box">
       <span><%= @item.text %></span> <!-- 商品説明を表示 -->

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,36 +22,34 @@
     <% end %>
     
     <div class="item-explain-box">
-      <%# 商品説明を表示 - テキストが存在しない場合の対策を追加 %>
-      <span><%= @item.text.presence || "説明はありません" %></span>
+      <span><%= @item.text %></span> <!-- 商品説明を表示 -->
     </div>
 
     <table class="detail-table">
       <tbody>
-        <%# 商品の詳細を表示 - それぞれの詳細について、モデルが存在するかを確認 %>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user&.nickname || "匿名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td> <!-- 出品者名を表示 -->
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @item.category&.name || "未設定" %></td>
+          <td class="detail-value"><%= @item.category.name %></td> <!-- カテゴリー名を表示 -->
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @item.condition&.name || "不明" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td> <!-- 商品の状態を表示 -->
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.shipping_fee&.name || "不明" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td> <!-- 発送料の負担を表示 -->
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.prefecture&.name || "不明" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td> <!-- 発送元の地域を表示 -->
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.delivery_time&.name || "不明" %></td>
+          <td class="detail-value"><%= @item.delivery_time.name %></td> <!-- 発送日の目安を表示 -->
         </tr>
       </tbody>
     </table>
@@ -86,7 +84,6 @@
   </div>
 
   <div class="links">
-    <%# 商品のナビゲーション - 商品が存在しない場合のエラーハンドリング %>
     <a href="<%= previous_item_path(@item) %>" class="change-item-btn">
       ＜ 前の商品
     </a>
@@ -94,8 +91,7 @@
       次の商品 ＞
     </a>
   </div>
-
-  <a href="<%= category_items_path(@item.category) %>" class="another-item"><%= @item.category.name %>の他の商品を見る</a>
+ <a href="#" class="another-item"><%= @item.category.name %>の他の商品を見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -11,23 +11,14 @@
       <%= image_tag(@item.image.attached? ? url_for(@item.image) : "item-sample.png", class: "item-box-img") %>
     </div>
 
-    <div class="item-price-box">
-      <span class="item-price">
-        <%# 商品価格を表示 - 通貨フォーマットに合わせる %>
-        ¥ <%= number_to_currency(@item.price, unit: "¥", format: "%n", delimiter: ",") %>
-      </span>
-      <span class="item-postage">
-        <%# 配送料負担を表示 - 関連するモデルから適切に取得 %>
-        <%= @item.shipping_fee.name %>
-      </span>
-    </div> 
-
-    <% if user_signed_in? && current_user == @item.user %> <!-- 出品者の場合 -->
-      <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %>
-      <p class="or-text">or</p>
-      <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
-    <% elsif user_signed_in? && !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
-      <%= link_to '購入画面に進む', new_order_path(item_id: @item.id), class: "item-red-btn" %>
+    <% if user_signed_in? %>
+      <% if current_user == @item.user %> <!-- 出品者の場合 -->
+        <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %>
+        <p class="or-text">or</p>
+        <%= link_to '削除', "#", method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
+      <% elsif !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
+        <%= link_to '購入画面に進む', "#", class: "item-red-btn" %>
+      <% end %>
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,7 +9,8 @@
     <div class="item-img-content">
       <%= image_tag(@item.image.attached? ? url_for(@item.image) : "item-sample.png", class: "item-box-img") %> <!-- 商品画像を表示 -->
 
-      <% if @item.sold_out? %>
+      <%# 購入機能実装時に以下のコードを有効にする %>
+      <%# <% if @item.sold_out? %> 
         <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
@@ -27,9 +28,11 @@
     <% if user_signed_in? && current_user == @item.user %> <!-- 出品者の場合 -->
       <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
+      <%# 削除機能実装後にリンクを修正する %>
+      <%= link_to '削除', '#', method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
     <% elsif user_signed_in? && !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
-      <%= link_to '購入画面に進む', new_item_order_path(@item), class: "item-red-btn" %>
+      <%# 購入機能実装後にリンクを修正する %>
+      <%= link_to '購入画面に進む', '#', class: "item-red-btn" %>
     <% end %> 
 
     <div class="item-explain-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   
   # 必要なアクションを定義
   resources :items do
-    resources :orders, only: [:new, :create] # ここで orders のルートを追加
+    # resources :orders, only: [:new, :create] # ここで orders のルートを追加
   end
 
   # カテゴリとブランドのルートを一旦削除（現時点で使わないため）


### PR DESCRIPTION
ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/a674327003d54a65d8be8bcec887f99f
必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/e23f42c6d239b0232fcb6821583e9b49
入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/7a7349752bfe5bbe99d3dbcecf46c7dc
何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/8168dd014cadb573c23c42d020a26568
ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
※済んでません
ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/ad585075aed668eeb288574065a8974e

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）

What

商品情報編集機能の実装
編集ページへのアクセス制御
ログイン状態でのみ、出品者自身が商品情報を編集できるように制御
出品者以外がアクセスした場合、トップページへ戦死します
画像保持のロジック

edit.html.erb 内の「もどる」ボタンを商品詳細ページへのリンクに設定し、編集途中の情報が破棄されるように実装

バリデーションとエラーハンドリングの強化
エラーメッセージの表示:
shared/error_messages を使って、エラー発生時に編集ページに戻り、エラーメッセージを表示する機能を実装

エラー発生時にも、入力済みの情報（画像・販売手数料・販売利益以外）は保持されるように実装
重複エラーメッセージの防止

重複したエラーメッセージが表示されないように、エラーメッセージの管理ロジックを修正。
Why
アクセス制御の必要性:

不正アクセスを防ぎ、ユーザーが自分の商品だけを編集できるようにすることで、セキュリティアップ

画像が消えることなく、編集作業がスムーズに行えるようにするため

