### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,7 +39,7 @@ class ItemsController < ApplicationController
     if @item.destroy
       redirect_to root_path, notice: '商品を削除しました。'
     else
-      redirect_to edit_item_path(@item), alert: '商品の削除に失敗しました。再試行してください。'
+      redirect_to item_path(@item), alert: '商品の削除に失敗しました。再試行してください。'
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,9 +17,21 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to @item, notice: '商品が作成されました。'
+      redirect_to root_path, notice: '商品が作成されました。'
     else
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    # 編集画面の表示
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to item_path(@item), notice: '商品情報が更新されました。'
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,11 +5,9 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.order(created_at: :desc)
-    Rails.logger.info("Item index accessed by #{current_user&.email || 'Guest'}")
   end
 
   def show
-    Rails.logger.info("Item #{@item.id} viewed by #{current_user&.email || 'Guest'}")
   end
 
   def new
@@ -19,20 +17,16 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      Rails.logger.info("Item #{@item.id} created by #{current_user.email}")
       redirect_to @item, notice: '商品が作成されました。'
     else
-      Rails.logger.error("Item creation failed: #{@item.errors.full_messages.join(', ')}")
       render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     if @item.destroy
-      Rails.logger.info("Item #{@item.id} destroyed by #{current_user.email}")
       redirect_to root_path, notice: '商品を削除しました。'
     else
-      Rails.logger.error("Item deletion failed: #{@item.errors.full_messages.join(', ')}")
       redirect_to edit_item_path(@item), alert: '商品の削除に失敗しました。再試行してください。'
     end
   end
@@ -46,9 +40,7 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
-    Rails.logger.info("Item #{@item.id} set for processing")
   rescue ActiveRecord::RecordNotFound
-    Rails.logger.error("Item with id #{params[:id]} not found")
     redirect_to root_path, alert: '指定された商品が見つかりません。'
   end
 
@@ -56,7 +48,6 @@ class ItemsController < ApplicationController
     return if current_user == @item.user
 
     flash[:alert] = 'この操作は許可されていません。'
-    Rails.logger.warn("Unauthorized access attempt by #{current_user.email} on item #{@item.id}")
     redirect_to root_path
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -12,6 +12,21 @@ class ItemsController < ApplicationController
     Rails.logger.info("Item #{@item.id} viewed by #{current_user&.email || 'Guest'}")
   end
 
+  def new
+    @item = Item.new
+  end
+
+  def create
+    @item = Item.new(item_params)
+    if @item.save
+      Rails.logger.info("Item #{@item.id} created by #{current_user.email}")
+      redirect_to @item, notice: '商品が作成されました。'
+    else
+      Rails.logger.error("Item creation failed: #{@item.errors.full_messages.join(', ')}")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
   def destroy
     if @item.destroy
       Rails.logger.info("Item #{@item.id} destroyed by #{current_user.email}")
@@ -43,9 +58,5 @@ class ItemsController < ApplicationController
     flash[:alert] = 'この操作は許可されていません。'
     Rails.logger.warn("Unauthorized access attempt by #{current_user.email} on item #{@item.id}")
     redirect_to root_path
-  end
-
-  def item_already_ordered?
-    @item.order.present?
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -30,7 +30,7 @@ class Item < ApplicationRecord
   end
 
   # 商品が売れているかを判断するメソッド
-  # def sold_out?
-  #   order.present?
-  # end
+  def sold_out?
+    order.present?
+  end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,9 +25,9 @@
     </div> %> 
 
    <% if user_signed_in? && current_user == @item.user %> <!-- 出品者の場合 -->
-  <%# <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %> %>
-  <%# <p class="or-text">or</p> %>
-  <%# <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %> %>
+  <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %>
+  <p class="or-text">or</p>
+  <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
 <% elsif user_signed_in? && !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
   <%# <%= link_to '購入画面に進む', new_item_order_path(@item), class: "item-red-btn" %> %>
 <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,9 +27,9 @@
    <% if user_signed_in? && current_user == @item.user %> <!-- 出品者の場合 -->
   <%= link_to '商品の編集', edit_item_path(@item), class: "item-red-btn" %>
   <p class="or-text">or</p>
-  <%= link_to '削除', item_path(@item), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-destroy" %>
+<%= link_to '削除', item_path(@item), data: { turbo_method: :delete, confirm: '本当に削除しますか？' }, class: "item-destroy" %>
 <% elsif user_signed_in? && !@item.sold_out? %> <!-- 購入画面に進むボタンを表示 -->
-  <%# <%= link_to '購入画面に進む', new_item_order_path(@item), class: "item-red-btn" %> %>
+  <%= link_to '購入画面に進む', new_item_order_path(@item), class: "item-red-btn" %>
 <% end %>
 
     <div class="item-explain-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   
   # 必要なアクションを定義
   resources :items do
-    resources :orders, only: [:new, :create] # ここで orders のルートを追加
+    resources :orders, only: [:new, :create, :destroy] # ここで orders のルートを追加
   end
 
   # カテゴリとブランドのルートを一旦削除（現時点で使わないため）

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ItemsController, type: :controller do
+  let!(:user) { create(:user) }
+  let!(:item) { create(:item, user:) }
+
+  describe 'DELETE #destroy' do
+    context 'when the user is logged in' do
+      before do
+        sign_in user
+      end
+
+      it 'deletes the item' do
+        expect do
+          delete :destroy, params: { id: item.id }
+        end.to change(Item, :count).by(-1)
+      end
+
+      it 'redirects to the root path' do
+        delete :destroy, params: { id: item.id }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when the user is not the owner of the item' do
+      let!(:other_user) { create(:user) }
+      before do
+        sign_in other_user
+      end
+
+      it 'does not delete the item' do
+        expect do
+          delete :destroy, params: { id: item.id }
+        end.to_not change(Item, :count)
+      end
+
+      it 'redirects to the root path with an alert' do
+        delete :destroy, params: { id: item.id }
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq '許可されていない操作です'
+      end
+    end
+
+    context 'when the user is not logged in' do
+      it 'does not delete the item and redirects to the login page' do
+        expect do
+          delete :destroy, params: { id: item.id }
+        end.to_not change(Item, :count)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,52 +1,48 @@
+# spec/controllers/items_controller_spec.rb
 require 'rails_helper'
 
 RSpec.describe ItemsController, type: :controller do
-  let!(:user) { create(:user) }
-  let!(:item) { create(:item, user:) }
+  let(:user) { create(:user) }
+  let(:item) { create(:item, user:) }
 
   describe 'DELETE #destroy' do
-    context 'when the user is logged in' do
-      before do
-        sign_in user
+    context 'ログインしていてアイテムの所有者の場合' do
+      before { sign_in user }
+
+      it 'アイテムが削除されること' do
+        expect { delete :destroy, params: { id: item.id } }
+          .to change(Item, :count).by(-1)
       end
 
-      it 'deletes the item' do
-        expect do
-          delete :destroy, params: { id: item.id }
-        end.to change(Item, :count).by(-1)
-      end
-
-      it 'redirects to the root path' do
+      it '成功メッセージと共にルートパスにリダイレクトされること' do
         delete :destroy, params: { id: item.id }
         expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to eq I18n.t('items.destroy.success')
       end
     end
 
-    context 'when the user is not the owner of the item' do
-      let!(:other_user) { create(:user) }
-      before do
-        sign_in other_user
+    context 'ログインしているがアイテムの所有者でない場合' do
+      let(:other_user) { create(:user) }
+      before { sign_in other_user }
+
+      it 'アイテムが削除されないこと' do
+        expect { delete :destroy, params: { id: item.id } }
+          .not_to change(Item, :count)
       end
 
-      it 'does not delete the item' do
-        expect do
-          delete :destroy, params: { id: item.id }
-        end.to_not change(Item, :count)
-      end
-
-      it 'redirects to the root path with an alert' do
+      it '警告メッセージと共にルートパスにリダイレクトされること' do
         delete :destroy, params: { id: item.id }
         expect(response).to redirect_to(root_path)
-        expect(flash[:alert]).to eq '許可されていない操作です'
+        expect(flash[:alert]).to eq I18n.t('items.not_authorized')
       end
     end
 
-    context 'when the user is not logged in' do
-      it 'does not delete the item and redirects to the login page' do
-        expect do
-          delete :destroy, params: { id: item.id }
-        end.to_not change(Item, :count)
+    context 'ログインしていない場合' do
+      it 'アイテムが削除されず、ログインページにリダイレクトされること' do
+        expect { delete :destroy, params: { id: item.id } }
+          .not_to change(Item, :count)
         expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to eq I18n.t('devise.failure.unauthenticated')
       end
     end
   end

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -2,10 +2,10 @@
 FactoryBot.define do
   factory :item do
     name { 'Test Item' }
-    text { 'This is a test item.' } # description -> text
+    text { 'This is a test item.' }
     category_id { 2 }
     condition_id { 2 }
-    shipping_id { 2 } # postage_payer_id -> shipping_id
+    shipping_fee_id { 2 }
     prefecture_id { 2 }
     delivery_time_id { 2 }
     price { 1000 }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Item, type: :model do
 
   describe '商品出品機能' do
     context '商品を出品できる時' do
-      it 'nameとtextとcategory_idとcondition_idとshipping_idとprefecture_idとdelivery_time_idとpriceと画像があれば登録できる' do
+      it 'nameとtextとcategory_idとcondition_idとshipping_fee_idとprefecture_idとdelivery_time_idとpriceと画像があれば登録できる' do
         expect(@item).to be_valid
       end
     end
@@ -44,9 +44,9 @@ RSpec.describe Item, type: :model do
       end
 
       it '配送料の負担が選択されていないと出品できない' do
-        @item.shipping_id = 1
+        @item.shipping_fee_id = 1 # ここを修正
         @item.valid?
-        expect(@item.errors.full_messages).to include 'Shipping を選択してください'
+        expect(@item.errors.full_messages).to include 'Shipping fee を選択してください'
       end
 
       it '発送元の地域が選択されていないと出品できない' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -61,4 +62,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Include Devise test helpers and FactoryBot syntax methods
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/f5b0ea8a8c1f34770b703d20b144cca5

What
ユーザーがログインしているかを確認し、ログインしていないユーザーには削除アクセスを制限
ビューの更新

商品詳細ページに削除ボタンを追加し、削除アクションを実行できるリンクを設定しました。このリンクは、出品者本人にのみ表示され、購入済み商品の場合は「削除」リンクを表示しないようにしました。

Why

セキュリティ対策

ログイン状態のユーザーのみが自身の出品物を削除できるようにすることで、システム全体のセキュリティを強化しました。これにより、他のユーザーによる不正削除を防ぎます

削除後にトップページにリダイレクトされることで、ユーザーは再度商品一覧を閲覧できるため、操作がスムーズになります。また、誤って商品を削除した場合でも、すぐに他の商品を確認できる利便性があります。
削除ボタンが出品者にのみ表示されなければ、他の人が勝手に削除してしまう